### PR TITLE
Prepend newlines to AI transfer message

### DIFF
--- a/langgraph_supervisor/handoff.py
+++ b/langgraph_supervisor/handoff.py
@@ -101,6 +101,7 @@ def create_handoff_back_messages(
     tool_call_id = str(uuid.uuid4())
     tool_name = f"transfer_back_to_{_normalize_agent_name(supervisor_name)}"
     tool_calls = [ToolCall(name=tool_name, args={}, id=tool_call_id)]
+    supervisor_name = supervisor_name.replace("_", " ").replace("-", " ")
     return (
         AIMessage(
             content=f"\n\nTransferring back to {supervisor_name}",

--- a/langgraph_supervisor/handoff.py
+++ b/langgraph_supervisor/handoff.py
@@ -104,7 +104,7 @@ def create_handoff_back_messages(
     supervisor_name = supervisor_name.replace("_", " ").replace("-", " ")
     return (
         AIMessage(
-            content=f"\n\nTransferring back to {supervisor_name}",
+            content=f"\n\nTransferring back to {supervisor_name}.",
             tool_calls=tool_calls,
             name=agent_name,
         ),

--- a/langgraph_supervisor/handoff.py
+++ b/langgraph_supervisor/handoff.py
@@ -103,7 +103,7 @@ def create_handoff_back_messages(
     tool_calls = [ToolCall(name=tool_name, args={}, id=tool_call_id)]
     return (
         AIMessage(
-            content=f"Transferring back to {supervisor_name}",
+            content=f"\n\nTransferring back to {supervisor_name}",
             tool_calls=tool_calls,
             name=agent_name,
         ),


### PR DESCRIPTION
Currently there's no spacing or line breaks before the AI message about transferring. This can look weird when following prior text. For example:
![image](https://github.com/user-attachments/assets/765455ae-73ff-403d-8fd6-43cc28e9f17a)
