### PR TITLE
add o3 and o4-mini to models that don't support parallel_tool_calls

### DIFF
--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -29,7 +29,7 @@ OutputMode = Literal["full_history", "last_message"]
 """
 
 
-MODELS_NO_PARALLEL_TOOL_CALLS = {"o3-mini", "o3", "o4-mini" ,"gpt-4.1"}
+MODELS_NO_PARALLEL_TOOL_CALLS = {"o3-mini", "o3", "o4-mini"}
 
 
 def _supports_disable_parallel_tool_calls(model: LanguageModelLike) -> bool:

--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -29,7 +29,7 @@ OutputMode = Literal["full_history", "last_message"]
 """
 
 
-MODELS_NO_PARALLEL_TOOL_CALLS = {"o3-mini"}
+MODELS_NO_PARALLEL_TOOL_CALLS = {"o3-mini", "o3", "o4-mini" ,"gpt-4.1"}
 
 
 def _supports_disable_parallel_tool_calls(model: LanguageModelLike) -> bool:


### PR DESCRIPTION
Minor hot fix to skip o3 and o4-mini that doesn't support parallel tool calls. 