### PR TITLE
Add license metadata to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ description = "An implementation of a supervisor multi-agent architecture using 
 authors = [
     {name = "Vadym Barda", email = "19161700+vbarda@users.noreply.github.com "}
 ]
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Adding [license metadata](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files) to `pyproject.toml` so that it is discoverable by automated tooling.