### PR TITLE
Added handling of alternative language model input

### DIFF
--- a/langgraph_supervisor/agent_name.py
+++ b/langgraph_supervisor/agent_name.py
@@ -1,8 +1,8 @@
 import re
 from typing import Literal
 
-from langchain_core.language_models import LanguageModelLike
-from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.language_models import LanguageModelInput, LanguageModelLike
+from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, convert_to_messages
 from langchain_core.runnables import RunnableLambda
 
 NAME_PATTERN = re.compile(r"<name>(.*?)</name>", re.DOTALL)
@@ -117,7 +117,11 @@ def with_agent_name(
             f"Invalid agent name mode: {agent_name_mode}. Needs to be one of: {AgentNameMode.__args__}"
         )
 
-    def process_input_messages(messages: list[BaseMessage]) -> list[BaseMessage]:
+    def process_input_messages(input: LanguageModelInput) -> list[BaseMessage]:
+        if isinstance(input, str):
+            messages = [SystemMessage(content=input)]
+        else:
+            messages = convert_to_messages(input)
         return [process_input_message(message) for message in messages]
 
     model = (


### PR DESCRIPTION
Currently, the formatting procedure to add agent names to the messages only supports a list of `BaseMessage`. However, there are alternative ways of supplying input to a `LanguageModel`, for example using a `ChatPromptValue`.

A quick modification of  `process_input_messages`  allows handling all `LanguageModelInputs` using the langchain-core library.