### PR TITLE
fix: bump `langgraph-prebuilt` dependency to support `post_model_hook`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "langgraph>=0.3.5",
-    "langgraph-prebuilt>=0.1.7",
+    "langgraph-prebuilt>=0.2.0",
     "langchain-core>=0.3.40"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -347,7 +347,7 @@ test = [
 requires-dist = [
     { name = "langchain-core", specifier = ">=0.3.40" },
     { name = "langgraph", specifier = ">=0.3.5" },
-    { name = "langgraph-prebuilt", specifier = ">=0.1.7" },
+    { name = "langgraph-prebuilt", specifier = ">=0.2.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Fix https://github.com/langchain-ai/langgraph-supervisor-py/issues/204