### PR TITLE
manually add END edge

### DIFF
--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -434,7 +434,7 @@ def create_supervisor(
     )
 
     builder = StateGraph(workflow_schema, context_schema=context_schema)
-    builder.add_node(supervisor_agent, destinations=tuple(agent_names) + (END,))
+    builder.add_node(supervisor_agent, destinations=tuple(agent_names))
     builder.add_edge(START, supervisor_agent.name)
     for agent in agents:
         builder.add_node(
@@ -447,5 +447,6 @@ def create_supervisor(
             ),
         )
         builder.add_edge(agent.name, supervisor_agent.name)
+    builder.add_edge(supervisor_name, END)
 
     return builder


### PR DESCRIPTION
add `END` edge manually instead of add `END` as a `destinations` param.

with this fix, we can easily add a addional node manaully, somthing like this:

<img width="550" height="265" alt="image" src="https://github.com/user-attachments/assets/8aff9a45-c45d-41cf-bbb7-cb962e8b02a8" />

without this fix:
<img width="596" height="245" alt="image" src="https://github.com/user-attachments/assets/c2888fa0-b2b7-43ea-b673-56792f2dc656" />

----
A simple test shows that both work without any significant difference.