### PR TITLE
fix: ensure order of agent names is preserved to avoid HTTP caching issues

### DIFF
--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -147,7 +147,7 @@ def _prepare_tool_node(
     tools: list[BaseTool | Callable] | ToolNode | None,
     handoff_tool_prefix: Optional[str],
     add_handoff_messages: bool,
-    agent_names: set[str],
+    agent_names: list[str],
 ) -> ToolNode:
     """Prepare the ToolNode to use in supervisor agent."""
     if isinstance(tools, ToolNode):
@@ -388,7 +388,9 @@ def create_supervisor(
     )
     workflow_schema = state_schema or _OuterState
 
-    agent_names = set()
+    agent_names = []
+    _agent_names_seen = set()
+
     for agent in agents:
         if agent.name is None or agent.name == "LangGraph":
             raise ValueError(
@@ -396,12 +398,13 @@ def create_supervisor(
                 "or via `graph.compile(name=name)`."
             )
 
-        if agent.name in agent_names:
+        if agent.name in _agent_names_seen:
             raise ValueError(
                 f"Agent with name '{agent.name}' already exists. Agent names must be unique."
             )
 
-        agent_names.add(agent.name)
+        _agent_names_seen.add(agent.name)
+        agent_names.append(agent.name)
 
     tool_node = _prepare_tool_node(
         tools,


### PR DESCRIPTION
## Motivation
This fixes an issue where the order of agent names was not preserved due to using a set. This names are being used when preparing the tool node, and are present on the final prompt to the LLM. On every run, the order was different causing issues when using `LANGSMITH_TEST_CACHE=path/to/cassets`.

<img width="1562" height="281" alt="image" src="https://github.com/user-attachments/assets/11ab1166-0402-432b-945b-c4758f704760" />
As seen on the screenshot above, each run was giving a different order.

This fix has reduced significantly the amount of real HTTP calls executed.

## Questions
* I could not find an easy way to add a test to this as the final prompt is quite buried in abstractions. Would love to hear from you an approach for this. Claude and Qwen also tried but failed.
* We still have some real HTTP calls due to the `tool.id` being different on every run. Any thoughts on this?