### PR TITLE
fix: fix parallel agent invocation by using create_react_agent with v1 version

### DIFF
--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -431,6 +431,7 @@ def create_supervisor(
         response_format=response_format,
         pre_model_hook=pre_model_hook,
         post_model_hook=post_model_hook,
+        version="v1" if parallel_tool_calls else "v2",
     )
 
     builder = StateGraph(workflow_schema, context_schema=context_schema)


### PR DESCRIPTION
### Summary
This PR fixes parallel agent invocation in the supervisor architecture by changing the create_react_agent version from v2 to v1 when parallel_tool_calls=True. ref Issue #230 
### Problem
When parallel_tool_calls=True is enabled in the supervisor, parallel agent handoffs were failing due to how different versions of create_react_agent handle tool calls:
v1: Handles multiple tool calls in a way that allows ToolNode to combine Send commands properly
v2: Creates separate Send commands for each tool call individually, preventing proper command combination
### Root Cause Analysis

1. ToolNode Command Combination: The ToolNode in LangGraph has special logic to combine multiple Send commands from parallel tool calls into a single parent command (see _combine_tool_outputs method in tool_node.py https://github.com/langchain-ai/langgraph/blob/main/libs/prebuilt/langgraph/prebuilt/tool_node.py#L403-L432)
2. v2 Behavior Prevents Combination: When using v2, create_react_agent generates individual Send commands for each tool call separately, which prevents the ToolNode from properly combining them for parallel execution (see https://github.com/langchain-ai/langgraph/blob/main/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py#L805-L809)
3. Handoff Tool Design: The handoff tools are specifically designed to work with this command combination mechanism. (see https://github.com/langchain-ai/langgraph-supervisor-py/blob/main/langgraph_supervisor/handoff.py#L106-L110)