### PR TITLE
update messages_key to _messages_key and similarly for _handle_tool_errors

### DIFF
--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -193,8 +193,8 @@ def _prepare_tool_node(
                 all_tools,
                 name=str(input_tool_node.name),
                 tags=list(input_tool_node.tags) if input_tool_node.tags else None,
-                handle_tool_errors=input_tool_node.handle_tool_errors,
-                messages_key=input_tool_node.messages_key,
+                handle_tool_errors=input_tool_node._handle_tool_errors,
+                messages_key=input_tool_node._messages_key,
             )
         else:
             tool_node = ToolNode(all_tools)


### PR DESCRIPTION


- Updated all instances of `messages_key` to `_messages_key`
- Renamed `handle_tool_errors` to `_handle_tool_errors`
- These changes align the codebase with breaking changes and conventions in the latest LangGraph release for improved forward compatibility and maintainability.
