### PR TITLE
docs: add OrcaRouter as a model provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,88 @@ result = app.invoke({
 > [!TIP]
 > For developing, debugging, and deploying AI agents and LLM applications, see [LangSmith](https://docs.langchain.com/langsmith/home).
 
+## Using OrcaRouter as the model provider
+
+You can use [OrcaRouter](https://www.orcarouter.ai) as the model provider for your supervisor workflow. OrcaRouter is an OpenAI-compatible gateway that routes requests to a wide range of models through a single endpoint, so you can swap models without changing your application code. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+```bash
+pip install langgraph-supervisor langchain-openai
+
+export ORCAROUTER_API_KEY=<your_api_key>
+```
+
+Point `ChatOpenAI` at OrcaRouter's endpoint and use the `orcarouter/auto` alias, which automatically routes each request to the best available model:
+
+```python
+import os
+
+from langchain_openai import ChatOpenAI
+
+from langgraph_supervisor import create_supervisor
+from langgraph.prebuilt import create_react_agent
+
+model = ChatOpenAI(
+    base_url="https://api.orcarouter.ai/v1",
+    model="orcarouter/auto",
+    api_key=os.environ["ORCAROUTER_API_KEY"],
+)
+
+def add(a: float, b: float) -> float:
+    """Add two numbers."""
+    return a + b
+
+def multiply(a: float, b: float) -> float:
+    """Multiply two numbers."""
+    return a * b
+
+def web_search(query: str) -> str:
+    """Search the web for information."""
+    return (
+        "Here are the headcounts for each of the FAANG companies in 2024:\n"
+        "1. **Facebook (Meta)**: 67,317 employees.\n"
+        "2. **Apple**: 164,000 employees.\n"
+        "3. **Amazon**: 1,551,000 employees.\n"
+        "4. **Netflix**: 14,000 employees.\n"
+        "5. **Google (Alphabet)**: 181,269 employees."
+    )
+
+math_agent = create_react_agent(
+    model=model,
+    tools=[add, multiply],
+    name="math_expert",
+    prompt="You are a math expert. Always use one tool at a time."
+)
+
+research_agent = create_react_agent(
+    model=model,
+    tools=[web_search],
+    name="research_expert",
+    prompt="You are a world class researcher with access to web search. Do not do any math."
+)
+
+workflow = create_supervisor(
+    [research_agent, math_agent],
+    model=model,
+    prompt=(
+        "You are a team supervisor managing a research expert and a math expert. "
+        "For current events, use research_agent. "
+        "For math problems, use math_agent."
+    )
+)
+
+app = workflow.compile()
+result = app.invoke({
+    "messages": [
+        {
+            "role": "user",
+            "content": "what's the combined headcount of the FAANG companies in 2024?"
+        }
+    ]
+})
+```
+
+You can also override the endpoint and model with the `ORCAROUTER_BASE_URL` and `ORCAROUTER_MODEL` environment variables.
+
 ## Message History Management
 
 You can control how messages from worker agents are added to the overall conversation history of the multi-agent system:


### PR DESCRIPTION
docs: add OrcaRouter as a model provider option

## What changed

Added a README section, "Using OrcaRouter as the model provider", that shows how to point a supervisor workflow at [OrcaRouter](https://www.orcarouter.ai) — an OpenAI-compatible gateway — by configuring `ChatOpenAI` with:

- `base_url="https://api.orcarouter.ai/v1"`
- `model="orcarouter/auto"` (auto-routing alias)
- `api_key=os.environ["ORCAROUTER_API_KEY"]`

The section mirrors the existing Quickstart example (two specialized agents + a supervisor) so users can drop in OrcaRouter with no code changes to `langgraph_supervisor`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Why

`langgraph_supervisor` is model-agnostic (users pass any LangChain chat model), so the natural integration point is documentation. This gives OrcaRouter a named, first-class spot in the README rather than being a generic "any OpenAI-compatible endpoint" example.

## Validation

- `pytest` — 13 passed (full suite, no regressions)
- `ruff format` / `ruff check` — clean with the pinned ruff 0.12.5 (CI-pinned via `uv.lock`)
- `ty check` — all checks passed
- Live test against `https://api.orcarouter.ai/v1` with a real `ORCAROUTER_API_KEY` and `orcarouter/auto`: the full supervisor workflow (tool calls + agent handoffs) ran end-to-end and returned the correct result.

Disclosure: I'm an engineer on the OrcaRouter team.
